### PR TITLE
Development

### DIFF
--- a/app/helpers/housekeeping.py
+++ b/app/helpers/housekeeping.py
@@ -19,7 +19,7 @@ class HousekeepingJob(threading.Thread):
         # Remove all existing whitelisted items if needed
         while not self.shutdown_flag.is_set():
             if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
-                settings.reload_configuration_file()  # reload configuration file, in case new whitelisted items were added by the analyst, they should be processed!
+                settings.reload_configuration_files()  # reload configuration file, in case new whitelisted items were added by the analyst, they should be processed!
 
                 try:
                     total_docs_whitelisted = es.remove_all_whitelisted_outliers()

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -38,7 +38,8 @@ class Settings:
         args = parser.parse_args()
         self.args = args
 
-        self.process_configuration_file(args.config)
+        print("processing args")
+        self.process_configuration_files(args.config)
 
         search_range = es.get_time_filter(days=self.config.getint("general", "history_window_days"), hours=self.config.getint("general", "history_window_hours"), timestamp_field=self.config.get("general", "timestamp_field", fallback="timestamp"))
 
@@ -52,14 +53,17 @@ class Settings:
         if args.run_mode == "interactive":
             pass
 
-    def reload_configuration_file(self):
-        self.process_configuration_file(self.args.config)
+    def reload_configuration_files(self):
+        self.process_configuration_files(self.args.config)
 
-    def process_configuration_file(self, path):
-        # Read configuration file
+    def process_configuration_files(self, config_paths):
+        # Read configuration files
         config = configparser.ConfigParser(interpolation=None)
         config.optionxform = str  # preserve case sensitivity in config keys, important for derived field names
-        config.read_file(open(path))
+
+        print(str(config_paths))
+        read_configuration_files = config.read(config_paths)
+        print(str(len(read_configuration_files)))
         self.config = config
 
     def get_sample_size(self, total_events=None, threshold_name=None):

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -26,6 +26,10 @@ class Settings:
     def __init__(self):
         self.args = None
         self.config = None
+
+        self.loaded_config_paths = None
+        self.failed_config_paths = None
+
         self.known_processes = None
 
         self.search_range_start = None
@@ -60,7 +64,9 @@ class Settings:
         config = configparser.ConfigParser(interpolation=None)
         config.optionxform = str  # preserve case sensitivity in config keys, important for derived field names
 
-        config.read(config_paths)
+        self.loaded_config_paths = config.read(config_paths)
+        self.failed_config_paths = set(config_paths) - set(self.loaded_config_paths)
+
         self.config = config
 
     def get_sample_size(self, total_events=None, threshold_name=None):

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -1,6 +1,5 @@
 import configparser
 import argparse
-from tldextract import tldextract
 from helpers.singleton import singleton
 from . import es
 
@@ -12,13 +11,13 @@ daemon_parser = subparsers.add_parser('daemon')
 tests_parser = subparsers.add_parser('tests')
 
 # Interactive mode - options
-interactive_parser.add_argument("--config", help="Configuration file location", required=True)
+interactive_parser.add_argument("--config", action='append', help="Configuration file location", required=True)
 
 # Daemon mode - options
-daemon_parser.add_argument("--config", help="Configuration file location", required=True)
+daemon_parser.add_argument("--config", action='append', help="Configuration file location", required=True)
 
 # Tests mode - options
-tests_parser.add_argument("--config", help="Configuration file location", required=True)
+tests_parser.add_argument("--config", action='append', help="Configuration file location", required=True)
 
 
 @singleton
@@ -32,9 +31,6 @@ class Settings:
         self.search_range_start = None
         self.search_range_end = None
         self.search_range = None
-
-        # TLD extractor - no internet required
-        self.offline_tld_extract = tldextract.TLDExtract(suffix_list_urls=None)
 
         self.process_arguments()
 

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -38,7 +38,6 @@ class Settings:
         args = parser.parse_args()
         self.args = args
 
-        print("processing args")
         self.process_configuration_files(args.config)
 
         search_range = es.get_time_filter(days=self.config.getint("general", "history_window_days"), hours=self.config.getint("general", "history_window_hours"), timestamp_field=self.config.get("general", "timestamp_field", fallback="timestamp"))
@@ -61,9 +60,7 @@ class Settings:
         config = configparser.ConfigParser(interpolation=None)
         config.optionxform = str  # preserve case sensitivity in config keys, important for derived field names
 
-        print(str(config_paths))
-        read_configuration_files = config.read(config_paths)
-        print(str(len(read_configuration_files)))
+        config.read(config_paths)
         self.config = config
 
     def get_sample_size(self, total_events=None, threshold_name=None):

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -162,9 +162,10 @@ def is_in_top_x(array, el, top_n):
 def extract_outlier_asset_information(fields, settings):
     outlier_assets = list()
     for (asset_field_name, asset_field_type) in settings.config.items("assets"):
-
         if dict_contains_dotkey(fields, asset_field_name):
-            outlier_assets.append(replace_placeholder_fields_with_values(asset_field_type + ": {" + asset_field_name + "}", fields))
+            asset_field_value = replace_placeholder_fields_with_values("{" + asset_field_name + "}", fields)
+            if asset_field_value:  # make sure we don't process empty process information, for example an empty user field
+                outlier_assets.append(replace_placeholder_fields_with_values(asset_field_type + ": {" + asset_field_name + "}", fields))
 
     return outlier_assets
 

--- a/app/outliers.py
+++ b/app/outliers.py
@@ -37,7 +37,15 @@ else:
 
 logging.logger.info("outliers.py started - contact: research@nviso.be")
 logging.logger.info("run mode: " + settings.args.run_mode)
+
 logging.print_generic_intro("initializing")
+logging.logger.info("loaded " + str(len(settings.loaded_config_paths)) + " configuration files")
+
+if len(settings.failed_config_paths) > 0:
+    logging.logger.warning("failed to load " + str(len(settings.failed_config_paths)) + " configuration files")
+
+    for failed_config_path in settings.failed_config_paths:
+        logging.logger.warning("failed to load " + str(failed_config_path))
 
 
 def perform_analysis():

--- a/app/outliers.py
+++ b/app/outliers.py
@@ -4,8 +4,7 @@ import traceback
 from datetime import datetime
 from croniter import croniter
 
-from helpers.singletons import settings
-from helpers.singletons import logging, es
+from helpers.singletons import settings, logging, es
 from helpers.utils import FileModificationWatcher
 from helpers.housekeeping import HousekeepingJob
 

--- a/app/outliers.py
+++ b/app/outliers.py
@@ -67,9 +67,11 @@ time_window_info = "processing events between " + search_start_range_printable +
 if settings.args.run_mode == "daemon":
     # In daemon mode, we also want to monitor the configuration file for changes.
     # In case of a change, we need to make sure that we are using this new configuration file
-    logging.logger.info("monitoring configuration file " + settings.args.config + " for changes")
+    for config_file in settings.args.config:
+        logging.logger.info("monitoring configuration file " + config_file + " for changes")
+
     file_mod_watcher = FileModificationWatcher()
-    file_mod_watcher.add_files([settings.args.config])
+    file_mod_watcher.add_files(settings.args.config)
 
     num_runs = 0
     while True:

--- a/app/tests/unit_tests/files/doc_with_asset_edgecases.json
+++ b/app/tests/unit_tests/files/doc_with_asset_edgecases.json
@@ -1,0 +1,103 @@
+{
+    "_id": "d8_9WWQBFCEzBdQxDtu-",
+    "_index": "logstash-eagleeye-osqueryfilter-2018.07.02",
+    "_score": null,
+    "_source": {
+        "@timestamp": "2018-07-02T07:54:30.549Z",
+        "@version": "1",
+        "OsqueryFilter": {
+            "address": "192.168.67.175",
+            "cmdline": "\"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\" -- \"http://link.belgianrail.be/mm/LC_7320_16226228_T6Q6D98Z9N5K_12178_aHR0cDovL3d3dy5iZWxnaWFucmFpbC5iZS9qcC9ubWJzLXJvdXRlcGxhbm5lci9xdWVyeS5leGUvbm4-dXRtX3NvdXJjZT1lbWFpbGluZzI5MDYyMDE4.act\"",
+            "cwd": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            "directory": "C:\\Program Files (x86)\\Google\\Chrome\\Application",
+            "egid": "-1",
+            "euid": "-1",
+            "family": "2",
+            "gid": "1646",
+            "md5": "cb2a1c2ea227f0338e7f3a8bc03c3d6e",
+            "name": "chrome.exe",
+            "nice": "8",
+            "on_disk": "1",
+            "parent": "7184",
+            "path": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            "pgroup": "-1",
+            "pid": "10496",
+            "port": "51507",
+            "protocol": "17",
+            "resident_size": "132431872",
+            "root": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            "sgid": "-1",
+            "sha1": "664bd49371068afce90927bdc08be2b01048b03a",
+            "sha256": "268a0463d7cb907d45e1c2ab91703e71734116f08b2c090e34c2d506183f9bca",
+            "start_time": "1530004847",
+            "state": "",
+            "suid": "-1",
+            "system_time": "32",
+            "threads": "32",
+            "total_size": "2203872661504",
+            "uid": "1646",
+            "user_time": "33",
+            "wired_size": "72572928"
+        },
+        "filename": "1530514470_osquery_get_all_processes_with_listening_conns.log",
+        "hashes": {
+            "unknown": [
+                "cb2a1c2ea227f0338e7f3a8bc03c3d6e"
+            ]
+        },
+        "meta": {
+            "command": {
+                "mode": "base_scan",
+                "name": "get_all_processes_with_listening_conns",
+                "query": "select p.*, hash.*, lp.* from processes p, listening_ports lp, hash WHERE lp.pid = p.pid AND hash.path = p.path;"
+            },
+            "deployment_name": "NVISO Workstations",
+            "filename": "osquery_get_all_processes_with_listening_conns.log",
+            "hostname": "",
+            "logged_in_users": [
+                "dummyuser1", "dummyuser2"
+            ],
+            "logged_in_users_details": [
+                {
+                    "host": "",
+                    "pid": "-1",
+                    "time": "0",
+                    "tty": "Services",
+                    "type": "disconnected",
+                    "user": ""
+                },
+                {
+                    "host": "",
+                    "pid": "-1",
+                    "time": "1529997655",
+                    "tty": "Console",
+                    "type": "active",
+                    "user": "tasselman"
+                }
+            ],
+            "output_file_path": "osquery_get_all_processes_with_listening_conns.log",
+            "timestamp": "2018-07-02T07:54:30.549523+00:00",
+            "toolname": "osquery"
+        },
+        "outliers": {
+            "observation": ["dummy observation"],
+            "reason": ["dummy reason"],
+            "total_outliers": 1,
+            "type": ["dummy type"],
+            "summary": ["dummy summary"]
+        },
+        "slave_name": "ee-slave-lab",
+        "smoky_filter_name": "OsqueryFilter",
+        "tags": [
+            "unknown_hashes",
+            "endpoint",
+            "outlier"
+        ],
+        "timestamp": "2018-07-02T07:54:30.549523+00:00",
+        "type": "eagleeye"
+    },
+    "_type": "doc",
+    "sort": [
+        42153
+    ]
+}

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -135,7 +135,7 @@ outlier_type=suspicious connection
 outlier_reason=beaconing TLS connection
 outlier_summary=beaconing TLS connection to {BroFilter.server_name}
 
-run_model=1
+run_model=0
 test_model=0
 
 ######################################################################################################################################################
@@ -152,7 +152,7 @@ outlier_type=powershell
 outlier_reason=powershell execution in hidden window
 outlier_summary=powershell execution in hidden window
 
-run_model=1
+run_model=0
 test_model=0
 
 ######################################################################################################################################################
@@ -196,7 +196,7 @@ outlier_type=outbound connection
 outlier_reason=rare outbound connection
 outlier_summary=rare outbound connection: {OsqueryFilter.name}
 
-run_model=1
+run_model=0
 test_model=0
 
 ######################################################################################################################################################
@@ -220,7 +220,7 @@ outlier_type=encoded commands
 outlier_reason=base64 encoded command line arguments
 outlier_summary=base64 encoded command line arguments for process {OsqueryFilter.name}
 
-run_model=1
+run_model=0
 test_model=0
 
 ######################################################################################################################################################

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -48,8 +48,37 @@ log_file=/mappedvolumes/logs/outliers.log
 # ASSET FIELDS
 ##############################
 [assets]
-meta.logged_in_users=user
-meta.hostname=host
+meta.logged_in_users = user
+meta.hostname = host
+suricatafilter.dest_ip = ip
+suricatafilter.src_ip = ip
+suricatafilter.tls.sni = domain
+suricatafilter.http.hostname = domain
+suricatafilter.dns.rrname = domain
+brofilter.server_name = domain
+brofilter.host = domain
+brofilter.query = domain
+brofilter.id_orig_h = ip
+brofilter.id_resp_h = ip
+brofilter.id_orig_h_geo_info.name = country
+brofilter.id_resp_h_geo_info.name = country
+brofilter.user = user
+brofilter.src = ip
+brofilter.dst = ip
+wineventfilter.hostname = host
+wineventfilter.workstationname = host
+wineventfilter.ipaddress = ip
+wineventfilter.targetusername = user
+wineventfilter.subjectusername = user
+syslogfilter.user-name = user
+syslogfilter.calling-station-id = mac
+syslogfilter.calling-station-id_geo_info.name = country
+syslogfilter.username = user
+binddnsfilter.clientip = ip
+binddnsfilter.query = domain
+officefilter.auditdata.userid = user
+officefilter.auditdata.mailboxownerupn = user
+officefilter.auditdata.clientipaddress = ip
 
 ##############################
 # NOTIFIER

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -14,10 +14,10 @@ es_timeout=300
 timestamp_field=timestamp
 
 # Save outlier detection results to Elasticsearch (if set to 0, Elasticsearch events won't be touched - great for testing)
-es_save_results=1
+es_save_results=0
 
 # Print outlier matches to the console. For testing purposes, it's advised to enable this so that the analyst can directly see on the command line which outliers are detected
-print_outliers_to_console=0
+print_outliers_to_console=1
 
 # How far back should we process events and look for outliers?
 # Both values are combined (for example the below will look back 7 days and 12 hours, up until right now).

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -21,7 +21,7 @@ print_outliers_to_console=1
 
 # How far back should we process events and look for outliers?
 # Both values are combined (for example the below will look back 7 days and 12 hours, up until right now).
-history_window_days=7
+history_window_days=1
 history_window_hours=12
 
 # Wipe all existing outliers that fall in the history window upon first run

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -14,7 +14,7 @@ es_timeout=300
 timestamp_field=timestamp
 
 # Save outlier detection results to Elasticsearch (if set to 0, Elasticsearch events won't be touched - great for testing)
-es_save_results=0
+es_save_results=1
 
 # Print outlier matches to the console. For testing purposes, it's advised to enable this so that the analyst can directly see on the command line which outliers are detected
 print_outliers_to_console=1
@@ -25,7 +25,7 @@ history_window_days=7
 history_window_hours=12
 
 # Wipe all existing outliers that fall in the history window upon first run
-es_wipe_all_existing_outliers=0
+es_wipe_all_existing_outliers=1
 
 # How often should existing outliers be checked for a match against the configuration whitelist, and should outlier fields be removed again from matched documents
 housekeeping_interval_seconds=60

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ requests-file==1.4.2
 ruamel.yaml==0.15.34
 SecretStorage==2.3.1
 six==1.11.0
-tldextract==2.1.0
 tzlocal==1.4
 urllib3==1.23
 pandas==0.22.0


### PR DESCRIPTION
- Remove old imports
- Support for multiple configuration files through --config argument
- Disable all default use cases in default configuration file to avoid conflict when running demos with multiple --config arguments
- more verbose output on which configuration files were loaded and which ones failed to load