### PR TITLE
Fix dependency version of tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn==0.19.1
-tensorflow>=1.12.1
+tensorflow==1.14.0
 certifi==2017.7.27.1
 chardet==3.0.4
 configparser==3.5.0
@@ -11,7 +11,7 @@ iso8601==0.1.12
 keyring==10.1
 keyrings.alt==1.3
 np==1.0.2
-numpy==1.13.3
+numpy==1.16.4
 pyasn1==0.1.9
 python-dateutil==2.6.1
 pytz==2017.2


### PR DESCRIPTION
With the current configuration, docker display this error on build: 
```
ERROR: tensorflow 1.14.0 has requirement numpy<2.0,>=1.14.5, but you'll have numpy 1.13.3 which is incompatible.
```
This pull request fix that problem