### PR TITLE
Fix typo in analyzer

### DIFF
--- a/app/helpers/analyzer.py
+++ b/app/helpers/analyzer.py
@@ -64,8 +64,8 @@ class Analyzer(abc.ABC):
         model_settings["outlier_type"] = settings.config.get(self.config_section_name, "outlier_type")
         model_settings["outlier_summary"] = settings.config.get(self.config_section_name, "outlier_summary")
 
-        self.should_test_model = settings.config.getboolean("general", "run_models") and settings.config.getboolean(self.config_section_name, "run_model")
-        self.should_run_model = settings.config.getboolean("general", "test_models") and settings.config.getboolean(self.config_section_name, "test_model")
+        self.should_run_model = settings.config.getboolean("general", "run_models") and settings.config.getboolean(self.config_section_name, "run_model")
+        self.should_test_model = settings.config.getboolean("general", "test_models") and settings.config.getboolean(self.config_section_name, "test_model")
 
         return model_settings
 


### PR DESCRIPTION
I think that `should_test_model` and `should_run_model` have been exchanged