### PR TITLE
Run housekeeping only if whitelist change

### DIFF
--- a/app/helpers/housekeeping.py
+++ b/app/helpers/housekeeping.py
@@ -13,9 +13,19 @@ class HousekeepingJob(threading.Thread):
         self.file_mod_watcher = FileModificationWatcher()
         self.file_mod_watcher.add_files(settings.args.config)
 
+        self.last_config_parameters = self._get_config_whitelist_parameters()
+
         # The shutdown_flag is a threading.Event object that
         # indicates whether the thread should be terminated.
         self.shutdown_flag = threading.Event()
+
+    def _get_config_whitelist_parameters(self):
+        return {
+            'whitelist_literals': settings.config.items("whitelist_literals"),
+            'whitelist_regexps': settings.config.items("whitelist_regexps"),
+            'es_wipe_all_whitelisted_outliers': settings.config.getboolean("general",
+                                                                           "es_wipe_all_whitelisted_outliers")
+        }
 
     def run(self):
         logging.logger.info('housekeeping thread #%s started' % self.ident)
@@ -33,20 +43,23 @@ class HousekeepingJob(threading.Thread):
             # should be processed!
             settings.reload_configuration_files()
 
-            if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
-                try:
-                    logging.logger.info("housekeeping - going to remove all whitelisted outliers")
-                    total_docs_whitelisted = es.remove_all_whitelisted_outliers()
+            if self.last_config_parameters != self._get_config_whitelist_parameters():
+                self.last_config_parameters = self._get_config_whitelist_parameters()
 
-                    if total_docs_whitelisted > 0:
-                        logging.logger.info(
-                            "housekeeping - total whitelisted documents cleared from outliers: " +
-                            "{:,}".format(total_docs_whitelisted))
-                    else:
-                        logging.logger.info("housekeeping - whitelist did not remove any outliers")
+                if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
+                    try:
+                        logging.logger.info("housekeeping - going to remove all whitelisted outliers")
+                        total_docs_whitelisted = es.remove_all_whitelisted_outliers()
 
-                except Exception:
-                    logging.logger.error("housekeeping - something went removing whitelisted outliers")
-                    logging.logger.error(traceback.format_exc())
+                        if total_docs_whitelisted > 0:
+                            logging.logger.info(
+                                "housekeeping - total whitelisted documents cleared from outliers: " +
+                                "{:,}".format(total_docs_whitelisted))
+                        else:
+                            logging.logger.info("housekeeping - whitelist did not remove any outliers")
 
-                logging.logger.info("housekeeping - finished round of cleaning whitelisted items")
+                    except Exception:
+                        logging.logger.error("housekeeping - something went removing whitelisted outliers")
+                        logging.logger.error(traceback.format_exc())
+
+                    logging.logger.info("housekeeping - finished round of cleaning whitelisted items")

--- a/app/helpers/housekeeping.py
+++ b/app/helpers/housekeeping.py
@@ -45,6 +45,7 @@ class HousekeepingJob(threading.Thread):
 
             if self.last_config_parameters != self._get_config_whitelist_parameters():
                 self.last_config_parameters = self._get_config_whitelist_parameters()
+                logging.logger.info("housekeeping - changes detected about the 'whitelist' in the configuration")
 
                 if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
                     try:

--- a/app/tests/unit_tests/test_housekeeping.py
+++ b/app/tests/unit_tests/test_housekeeping.py
@@ -20,7 +20,7 @@ class TestHousekeeping(unittest.TestCase):
     def tearDown(self):
         self.test_es.restore_es()
 
-    def test_housekeeping_correctly_remove_whitelist(self):
+    def test_housekeeping_correctly_remove_whitelisted_outlier_when_file_modification(self):
         backup_args_config = settings.args.config[:]
         settings.args.config = [test_file_no_whitelist_path_config]
         housekeeping = HousekeepingJob()

--- a/app/tests/unit_tests/test_housekeeping.py
+++ b/app/tests/unit_tests/test_housekeeping.py
@@ -48,3 +48,28 @@ class TestHousekeeping(unittest.TestCase):
         settings.args.config = backup_args_config
 
         self.assertEqual(result, doc_without_outlier)
+
+    def test_housekeeping_not_execute_no_whitelist_parameter_change(self):
+        backup_args_config = settings.args.config[:]
+        settings.args.config = [test_file_no_whitelist_path_config]
+        housekeeping = HousekeepingJob()
+
+        # Add document to "Database"
+        doc_with_outlier = copy.deepcopy(doc_with_outlier_test_file)
+        self.test_es.add_doc(doc_with_outlier)
+
+        # Update configuration (create new section and append to default)
+        filecontent = "[dummy_section]\nparam=1"
+
+        with open(test_file_no_whitelist_path_config, 'a') as test_file:
+            test_file.write(filecontent)
+
+        housekeeping.execute_housekeeping()
+
+        # Fetch result
+        result = [elem for elem in self.test_es.scan()][0]
+
+        # Restore configuration
+        settings.args.config = backup_args_config
+
+        self.assertEqual(result, doc_with_outlier)


### PR DESCRIPTION
Avoid the run of Housekeeping if the configuration is just reload.  Now, the housekeeping run if the whitelist parameters (`whitelist_literals`, `whitelist_regexps` or `es_wipe_all_whitelisted_outliers`) changes.