### PR TITLE
Refactor settings

### DIFF
--- a/app/helpers/es.py
+++ b/app/helpers/es.py
@@ -241,7 +241,6 @@ class ES:
 
     def extract_derived_fields(self, doc_fields):
         derived_fields = dict()
-
         for field_name, grok_pattern in self.settings.config.items("derivedfields"):
             if helpers.utils.dict_contains_dotkey(doc_fields, field_name, case_sensitive=False):
                 if grok_pattern in self.grok_filters.keys():

--- a/app/helpers/es.py
+++ b/app/helpers/es.py
@@ -241,6 +241,7 @@ class ES:
 
     def extract_derived_fields(self, doc_fields):
         derived_fields = dict()
+
         for field_name, grok_pattern in self.settings.config.items("derivedfields"):
             if helpers.utils.dict_contains_dotkey(doc_fields, field_name, case_sensitive=False):
                 if grok_pattern in self.grok_filters.keys():

--- a/app/helpers/housekeeping.py
+++ b/app/helpers/housekeeping.py
@@ -31,7 +31,7 @@ class HousekeepingJob(threading.Thread):
         if len(self.file_mod_watcher.files_changed()) > 0:
             # reload configuration file, in case new whitelisted items were added by the analyst, they
             # should be processed!
-            settings.reload_configuration_files()
+            settings.process_arguments()
 
             if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
                 try:

--- a/app/helpers/housekeeping.py
+++ b/app/helpers/housekeeping.py
@@ -31,7 +31,7 @@ class HousekeepingJob(threading.Thread):
         if len(self.file_mod_watcher.files_changed()) > 0:
             # reload configuration file, in case new whitelisted items were added by the analyst, they
             # should be processed!
-            settings.process_arguments()
+            settings.process_configuration_files()
 
             if settings.config.getboolean("general", "es_wipe_all_whitelisted_outliers"):
                 try:

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -2,6 +2,7 @@ import configparser
 import argparse
 
 from helpers.singleton import singleton
+import copy
 
 parser = argparse.ArgumentParser()
 
@@ -31,7 +32,7 @@ class Settings:
         self.failed_config_paths = None
 
         self.args = parser.parse_args()
-        self.backup_args_config = self.args.config[:]
+        self.default_args_config = copy.deepcopy(self.args.config)
         self.process_configuration_files()
 
     def process_configuration_files(self):
@@ -59,5 +60,5 @@ class Settings:
         """
         Only use by tests to restore the default configuration
         """
-        self.args.config = self.backup_args_config
+        self.args.config = self.default_args_config
         self.process_configuration_files()

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -38,9 +38,6 @@ class Settings:
 
         self.process_configuration_files(args.config)
 
-    def reload_configuration_files(self):
-        self.process_configuration_files(self.args.config)
-
     def process_configuration_files(self, config_paths):
         # Read configuration files
         config = configparser.ConfigParser(interpolation=None)

--- a/app/helpers/settings.py
+++ b/app/helpers/settings.py
@@ -30,15 +30,13 @@ class Settings:
         self.loaded_config_paths = None
         self.failed_config_paths = None
 
-        self.process_arguments()
+        self.args = parser.parse_args()
+        self.backup_args_config = self.args.config[:]
+        self.process_configuration_files()
 
-    def process_arguments(self):
-        args = parser.parse_args()
-        self.args = args
+    def process_configuration_files(self):
+        config_paths = self.args.config
 
-        self.process_configuration_files(args.config)
-
-    def process_configuration_files(self, config_paths):
         # Read configuration files
         config = configparser.ConfigParser(interpolation=None)
         config.optionxform = str  # preserve case sensitivity in config keys, important for derived field names
@@ -47,3 +45,19 @@ class Settings:
         self.failed_config_paths = set(config_paths) - set(self.loaded_config_paths)
 
         self.config = config
+
+    def _change_configuration_path(self, new_path):
+        """
+        Only use by tests
+
+        :param new_path: the new path of the configuration
+        """
+        self.args.config = [new_path]
+        self.process_configuration_files()
+
+    def _restore_default_configuration_path(self):
+        """
+        Only use by tests to restore the default configuration
+        """
+        self.args.config = self.backup_args_config
+        self.process_configuration_files()

--- a/app/outliers.py
+++ b/app/outliers.py
@@ -151,7 +151,7 @@ if settings.args.run_mode == "daemon":
             # Check for configuration file changes and load them in case it's needed
             if len(file_mod_watcher.files_changed()) > 0:
                 logging.logger.info("configuration file changed, reloading")
-                settings.process_arguments()
+                settings.process_configuration_files()
                 should_schedule_next_run = True
 
             if should_schedule_next_run:
@@ -161,7 +161,7 @@ if settings.args.run_mode == "daemon":
 
             time.sleep(5)
 
-        settings.process_arguments()  # Refresh settings
+        settings.process_configuration_files()  # Refresh settings
 
         if first_run:
             first_run = False

--- a/app/tests/unit_tests/test_analyzer.py
+++ b/app/tests/unit_tests/test_analyzer.py
@@ -23,8 +23,7 @@ class TestAnalyzer(unittest.TestCase):
 
     def tearDown(self):
         # restore the default configuration file so we don't influence other unit tests that use the settings singleton
-        settings.process_configuration_files("/defaults/outliers.conf")
-        settings.process_arguments()
+        settings._restore_default_configuration_path()
         self.test_es.restore_es()
 
     def _preperate_data_terms(self):
@@ -37,7 +36,7 @@ class TestAnalyzer(unittest.TestCase):
         return eval_terms_array, aggregator_value, target_value, observations, doc
 
     def test_simple_process_outlier_return_good_outlier(self):
-        settings.process_configuration_files("/app/tests/unit_tests/files/analyzer_test_01.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/analyzer_test_01.conf")
         analyzer = TestStubAnalyzer("analyzer_dummy_test")
 
         doc_without_outlier = copy.deepcopy(doc_without_outlier_test_file)
@@ -50,7 +49,7 @@ class TestAnalyzer(unittest.TestCase):
         self.assertEqual(outlier, expected_outlier)
 
     def test_simple_process_outlier_save_es(self):
-        settings.process_configuration_files("/app/tests/unit_tests/files/analyzer_test_01.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/analyzer_test_01.conf")
         analyzer = TestStubAnalyzer("analyzer_dummy_test")
 
         doc_without_outlier = copy.deepcopy(doc_without_outlier_test_file)

--- a/app/tests/unit_tests/test_housekeeping.py
+++ b/app/tests/unit_tests/test_housekeeping.py
@@ -19,10 +19,10 @@ class TestHousekeeping(unittest.TestCase):
 
     def tearDown(self):
         self.test_es.restore_es()
+        settings._restore_default_configuration_path()
 
     def test_housekeeping_correctly_remove_whitelist(self):
-        backup_args_config = settings.args.config[:]
-        settings.args.config = [test_file_no_whitelist_path_config]
+        settings._change_configuration_path(test_file_no_whitelist_path_config)
         housekeeping = HousekeepingJob()
 
         # Add document to "Database"
@@ -43,8 +43,5 @@ class TestHousekeeping(unittest.TestCase):
 
         # Compute expected result:
         doc_without_outlier = copy.deepcopy(doc_without_outlier_test_file)
-
-        # Restore configuration
-        settings.args.config = backup_args_config
 
         self.assertEqual(result, doc_without_outlier)

--- a/app/tests/unit_tests/test_outliers.py
+++ b/app/tests/unit_tests/test_outliers.py
@@ -21,8 +21,7 @@ class TestOutlierOperations(unittest.TestCase):
 
     def tearDown(self):
         # restore the default configuration file so we don't influence other unit tests that use the settings singleton
-        settings.process_configuration_files("/defaults/outliers.conf")
-        settings.process_arguments()
+        settings._restore_default_configuration_path()
         self.test_es.restore_es()
 
     def test_add_outlier_to_doc(self):
@@ -145,7 +144,7 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier = Outlier(outlier_type="dummy type", outlier_reason="dummy reason",
                                outlier_summary="dummy summary")
 
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_01.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_01.conf")
         self.assertTrue(test_outlier.is_whitelisted(additional_dict_values_to_check=orig_doc))
 
     def test_single_literal_to_match_in_doc_with_outlier(self):
@@ -153,7 +152,7 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier = Outlier(outlier_type="dummy type", outlier_reason="dummy reason",
                                outlier_summary="dummy summary")
 
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_02.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_02.conf")
         self.assertTrue(test_outlier.is_whitelisted(additional_dict_values_to_check=orig_doc))
 
     def test_single_literal_not_to_match_in_doc_with_outlier(self):
@@ -161,7 +160,7 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier = Outlier(outlier_type="dummy type", outlier_reason="dummy reason",
                                outlier_summary="dummy summary")
 
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_03.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_03.conf")
         self.assertFalse(test_outlier.is_whitelisted(additional_dict_values_to_check=orig_doc))
 
     def test_whitelist_config_file_multi_item_match_with_three_fields_and_whitespace(self):
@@ -169,7 +168,7 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier = Outlier(outlier_type="dummy type", outlier_reason="dummy reason",
                                outlier_summary="dummy summary")
 
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_04.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_04.conf")
         self.assertTrue(test_outlier.is_whitelisted(additional_dict_values_to_check=orig_doc))
 
     def test_whitelist_config_file_multi_item_mismatch_with_three_fields_and_whitespace(self):
@@ -177,14 +176,14 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier = Outlier(outlier_type="dummy type", outlier_reason="dummy reason",
                                outlier_summary="dummy summary")
 
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_05.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_05.conf")
         self.assertFalse(test_outlier.is_whitelisted(additional_dict_values_to_check=orig_doc))
 
     def test_whitelist_config_change_remove_multi_item_literal(self):
         doc_with_outlier = copy.deepcopy(doc_with_outlier_test_file)
         doc_without_outlier = copy.deepcopy(doc_without_outlier_test_file)
         self.test_es.add_doc(doc_with_outlier)
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_01_with_general.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_01_with_general.conf")
         es.remove_all_whitelisted_outliers()
         result = [elem for elem in es.scan()][0]
         self.assertEqual(result, doc_without_outlier)
@@ -192,7 +191,7 @@ class TestOutlierOperations(unittest.TestCase):
     def test_whitelist_config_change_single_literal_not_to_match_in_doc_with_outlier(self):
         doc_with_outlier = copy.deepcopy(doc_with_outlier_test_file)
         self.test_es.add_doc(doc_with_outlier)
-        settings.process_configuration_files("/app/tests/unit_tests/files/whitelist_tests_03_with_general.conf")
+        settings._change_configuration_path("/app/tests/unit_tests/files/whitelist_tests_03_with_general.conf")
         es.remove_all_whitelisted_outliers()
         result = [elem for elem in es.scan()][0]
         self.assertEqual(result, doc_with_outlier)


### PR DESCRIPTION
In this issue, two methods have been removed:
- `process_arguments`
- `reload_configuration_files`

All the parameters are fetch in the init method. Two methods have been created to facilitate testing