### PR TITLE
Remove deepcopy for whitelist check (SMALL)

### DIFF
--- a/app/helpers/outlier.py
+++ b/app/helpers/outlier.py
@@ -20,12 +20,7 @@ class Outlier:
     # Example: "dns_tunneling_fp = rule_updates.et.com, intel_server" -> should match both values across the entire
     # event (rule_updates.et.com and intel_server);
     def is_whitelisted(self, additional_dict_values_to_check=None):
-        if additional_dict_values_to_check is not None:
-            additional_dict_values = copy.deepcopy(additional_dict_values_to_check)
-        else:
-            additional_dict_values = dict()
-        additional_dict_values["__outlier_dict"] = self.outlier_dict
-        return Outlier.is_whitelisted_doc(additional_dict_values)
+        return Outlier.is_whitelisted_doc({'': self.outlier_dict, '_': additional_dict_values_to_check})
 
     def get_outlier_dict_of_arrays(self):
         outlier_dict_of_arrays = dict()


### PR DESCRIPTION
Solution to not deepcopy the document when we check whitelist