### PR TITLE
Fix and simplify `is_outlier` function (SMALL)

### DIFF
--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -275,15 +275,9 @@ def get_mad_decision_frontier(values_array, trigger_sensitivity, trigger_on):
 
 def is_outlier(term_value_count, decision_frontier, trigger_on):
     if trigger_on == "high":
-        if term_value_count > decision_frontier:
-            return True
-        else:
-            return False
+        return term_value_count > decision_frontier
     elif trigger_on == "low":
-        if term_value_count < decision_frontier:
-            return decision_frontier
-        else:
-            return False
+        return term_value_count < decision_frontier
     else:
         raise ValueError("Unexpected outlier trigger condition " + trigger_on)
 


### PR DESCRIPTION
If `decision_frontier` was set to zero, the `is_outlier` is always False.  We never use the value return by `is_outlier` for other stuff that a condition.