### PR TITLE
Outilers in document are list only if multiple exist.

### DIFF
--- a/app/tests/unit_tests/files/doc_with_outlier_list.json
+++ b/app/tests/unit_tests/files/doc_with_outlier_list.json
@@ -80,11 +80,11 @@
             "toolname": "osquery"
         },
         "outliers": {
-            "observation": "dummy observation",
-            "reason": "dummy reason",
+            "observation": ["dummy observation"],
+            "reason": ["dummy reason"],
             "total_outliers": 1,
-            "type": "dummy type",
-            "summary": "dummy summary"
+            "type": ["dummy type"],
+            "summary": ["dummy summary"]
         },
         "slave_name": "ee-slave-lab",
         "smoky_filter_name": "OsqueryFilter",

--- a/app/tests/unit_tests/test_outliers.py
+++ b/app/tests/unit_tests/test_outliers.py
@@ -15,6 +15,7 @@ doc_without_outlier_test_file = json.load(open("/app/tests/unit_tests/files/doc_
 doc_without_outlier_without_score_test_file = json.load(open(
     "/app/tests/unit_tests/files/doc_without_outlier_without_score.json"))
 doc_with_outlier_test_file = json.load(open("/app/tests/unit_tests/files/doc_with_outlier.json"))
+doc_with_outlier_list_test_file = json.load(open("/app/tests/unit_tests/files/doc_with_outlier_list.json"))
 doc_with_two_outliers_test_file = json.load(open("/app/tests/unit_tests/files/doc_with_two_outliers.json"))
 doc_with_three_outliers_test_file = json.load(open("/app/tests/unit_tests/files/doc_with_three_outliers.json"))
 
@@ -46,7 +47,7 @@ class TestOutlierOperations(unittest.TestCase):
         test_outlier.outlier_dict["observation"] = "dummy observation"
 
         doc_with_outlier = helpers.es.add_outlier_to_document(test_outlier)
-        self.assertDictEqual(doc_with_outlier_test_file, doc_with_outlier)
+        self.assertDictEqual(doc_with_outlier_list_test_file, doc_with_outlier)
 
     def test_remove_outlier_from_doc(self):
         doc = copy.deepcopy(doc_without_outlier_test_file)


### PR DESCRIPTION
Otherwhise, it is just a string (adapt test to this modification)

Notice that here it impact only document that are already in elasticsearch.

This problem was not detected before (and normaly doesn't impact the result) because the element in document are also taking into account. So outlier summary, type ect are present in the list tested with the whitelist...

:warning: A test must be done to be sure this is the case for all ElasticSearch version
Here test with 7.2.0