### PR TITLE
Fix missing bulk ES action flushing

### DIFF
--- a/app/outliers.py
+++ b/app/outliers.py
@@ -274,6 +274,7 @@ def perform_analysis(housekeeping_job):
             analyzer.evaluate_model()
             analyzer.analysis_end_time = datetime.today().timestamp()
             analyzer.completed_analysis = True
+            es.flush_bulk_actions()
 
             logging.logger.info("finished processing use case - %d / %d [%s%% done]", index + 1,
                                 len(analyzers_to_evaluate),


### PR DESCRIPTION
The current Elasticsearch implementation misses the flushing of the last incomplete batch of actions. This results in up to `BULK_FLUSH_SIZE-1` actions being lost. In a situation where few outliers are detected (`<1000` by default), none of them would be flagged in ES.

This PR introduces the `ES::flush()` method to flush any internal buffers, such as the actions buffer through `ES::flush_bulk_actions()`. The `ES::flush()` method is itself called by `perform_analysis()` to apply any outstanding actions in ES.

Note that `perform_analysis()` could also call `ES::flush_bulk_actions()` which I however find too internal to the class, hence the more generic `ES::flush()`.