### PR TITLE
Fix issues 459

### DIFF
--- a/app/helpers/es.py
+++ b/app/helpers/es.py
@@ -88,7 +88,7 @@ class ES:
         authentication_url = "%s://%s:%s@%s" % (protocol,
                                                 self.settings.config.get("general", "es_username"),
                                                 self.settings.config.get("general", "es_password"),
-                                         Yes        host_and_port)
+                                                host_and_port)
         return authentication_url
 
     def _get_history_window(self, model_settings=None):

--- a/app/helpers/es.py
+++ b/app/helpers/es.py
@@ -1,7 +1,6 @@
 import json
 import datetime as dt
 import math
-import re
 
 from collections import defaultdict
 from itertools import chain
@@ -9,6 +8,8 @@ from itertools import chain
 from pygrok import Grok
 from elasticsearch import helpers as eshelpers, Elasticsearch
 from elasticsearch.exceptions import AuthenticationException, ConnectionError
+
+from configparser import NoOptionError
 
 import helpers.utils
 import helpers.logging
@@ -54,8 +55,11 @@ class ES:
 
         :return: Connection object if connection with Elasticsearch succeeded, False otherwise
         """
-        http_auth = (self.settings.config.get("general", "es_username"),
-                     self.settings.config.get("general", "es_password"))
+        try:
+            http_auth = (self.settings.config.get("general", "es_username"),
+                         self.settings.config.get("general", "es_password"))
+        except NoOptionError:
+            http_auth = ("", "")
 
         self.conn = Elasticsearch([self.settings.config.get("general", "es_url")],
                                   http_auth=http_auth,
@@ -69,7 +73,7 @@ class ES:
                                      (self.settings.config.get("general", "es_url")))
             result = self.conn
         except AuthenticationException:
-            self.logging.logger.error("could not connect to Elasticsearch on host %s due to authentication error" %
+            self.logging.logger.error("could not connect to Elasticsearch on host %s due to authentication error." %
                                       (self.settings.config.get("general", "es_url")))
             result = False
         except ConnectionError:

--- a/defaults/outliers.conf
+++ b/defaults/outliers.conf
@@ -5,6 +5,8 @@
 
 # Elasticsearch parameters
 es_url=http://esnode1:9200
+es_username=
+es_password=
 es_index_pattern=logstash-eagleeye-*
 es_scan_size=10000
 es_scroll_time=25m

--- a/documentation/CONFIG_PARAMETERS.md
+++ b/documentation/CONFIG_PARAMETERS.md
@@ -56,6 +56,16 @@
     <td class="tg-0pky">URL to connect to ES</td>
     <td class="tg-0pky"></td>
   </tr>
+   <tr>
+    <td class="tg-0pky">es_username</td>
+    <td class="tg-0pky">Username if ES authentication is required</td>
+    <td class="tg-0pky"></td>
+  </tr>
+   <tr>
+    <td class="tg-0pky">es_password</td>
+    <td class="tg-0pky">Password if ES authentication is required</td>
+    <td class="tg-0pky"></td>
+  </tr>
   <tr>
     <td class="tg-0pky">es_timeout</td>
     <td class="tg-0pky">Integer</td>


### PR DESCRIPTION
closes #459 Elasticsearch Authentication
Authentication available via the configuration file by specifying username/password in the respective fields es_username/es_password