### PR TITLE
Fix ES dsl search_query generation to make it compatible with ES 7.8.0.

### DIFF
--- a/app/helpers/es.py
+++ b/app/helpers/es.py
@@ -630,7 +630,7 @@ def build_search_query(bool_clause=None,
         query["query"]["bool"]["filter"].append(search_range)
 
     if search_query:
-        query["query"]["bool"]["filter"].append(search_query["filter"].copy())
+        query["query"]["bool"]["filter"].extend(search_query["filter"].copy())
 
     if highlight_settings:
         query["highlight"] = highlight_settings


### PR DESCRIPTION
Should close #555. 
It seems that the ES dsl search query was wrongly generated but correctly handled in previous versions of ES.
I tested in local VM and the modification done here are compatible with ES 7.8.0 and 7.6.2. 

Would be maybe necessary to test it further on more environment and ES versions. 
What do you think?